### PR TITLE
Correction of an installation error in a future version of zpm

### DIFF
--- a/src/Bmap/Address.cls
+++ b/src/Bmap/Address.cls
@@ -14,5 +14,26 @@ Property State As %String(MAXLEN = 2, POPSPEC = "USState()");
 /// The 5-digit U.S. Zone Improvement Plan (ZIP) code.
 Property Zip As %String(MAXLEN = 5, POPSPEC = "USZip()");
 
+Storage Default
+{
+<Data name="AddressState">
+<Value name="1">
+<Value>Street</Value>
+</Value>
+<Value name="2">
+<Value>City</Value>
+</Value>
+<Value name="3">
+<Value>State</Value>
+</Value>
+<Value name="4">
+<Value>Zip</Value>
+</Value>
+</Data>
+<State>AddressState</State>
+<StreamLocation>^Bmap.AddressS</StreamLocation>
+<Type>%Storage.Serial</Type>
+}
+
 }
 


### PR DESCRIPTION
This module has a persistent class without any specific storage and this is stated in the error.
The author must define the Storage and publish the new version. The new version of the zpm will have an installation error.

%SYS>ver
%SYS> zpm 0.2.15-dev.228.5

zpm:iris-test>IRIS20203>BITMAPADOPTION>install bitmap-adoption

[bitmap-adoption] Reload START (/opt2/isc/iris20203/mgr/.modules/BITMAPADOPTION/bitmap-adoption/1.0.4/)
[bitmap-adoption] Reload SUCCESS
[bitmap-adoption] Module object refreshed.
[bitmap-adoption] Validate START
[bitmap-adoption] Validate SUCCESS
[bitmap-adoption] Compile START
[bitmap-adoption] Compile FAILURE
ERROR! Storage on class Bmap.Address modified by storage compiler, developer should have run ^build to make sure all storage is updated correctly and saved to Perforce